### PR TITLE
Update constructor 0.37.1

### DIFF
--- a/data/packages.php
+++ b/data/packages.php
@@ -502,7 +502,8 @@ $packages = [
 	"lua/Constructor" => [
 		"priority" => 2,
 		"author" => "hexarobi",
-		"version" => "0.37r",
+		"description" => "Load and edit custom map, vehicle and skin files in JSON, XML or INI format.",
+		"version" => "0.37.1r",
 		"depends" => [
 			"lua/natives-1672190175",
 			"lua/iniparser",
@@ -511,8 +512,8 @@ $packages = [
 			"lua/quaternionLib",
 		],
 		"files" => [
-			"Constructor.lua" => "raw.githubusercontent.com/hexarobi/stand-lua-constructor/dc8c2e443c593c3029b17956ab17c453da554cad/Constructor.lua",
-			"lib/auto-updater.lua" => "raw.githubusercontent.com/hexarobi/stand-lua-constructor/dc8c2e443c593c3029b17956ab17c453da554cad/lib/auto-updater.lua",
+			"Constructor.lua" => "raw.githubusercontent.com/hexarobi/stand-lua-constructor/edf67b2210b45675dd18a0127177ef7ed2205fa6/Constructor.lua",
+			"lib/auto-updater.lua" => "raw.githubusercontent.com/hexarobi/stand-lua-constructor/edf67b2210b45675dd18a0127177ef7ed2205fa6/lib/auto-updater.lua",
 			"lib/constructor/constants.lua" => "raw.githubusercontent.com/hexarobi/stand-lua-constructor/dc8c2e443c593c3029b17956ab17c453da554cad/lib/constructor/constants.lua",
 			"lib/constructor/constructor_lib.lua" => "raw.githubusercontent.com/hexarobi/stand-lua-constructor/dc8c2e443c593c3029b17956ab17c453da554cad/lib/constructor/constructor_lib.lua",
 			"lib/constructor/convertors.lua" => "raw.githubusercontent.com/hexarobi/stand-lua-constructor/dc8c2e443c593c3029b17956ab17c453da554cad/lib/constructor/convertors.lua",

--- a/data/packages.php
+++ b/data/packages.php
@@ -513,7 +513,7 @@ $packages = [
 		],
 		"files" => [
 			"Constructor.lua" => "raw.githubusercontent.com/hexarobi/stand-lua-constructor/58d3c90dbb0cd3cd36f8c93d55276d7e96dae828/Constructor.lua",
-			"lib/auto-updater.lua" => "raw.githubusercontent.com/hexarobi/stand-lua-constructor/edf67b2210b45675dd18a0127177ef7ed2205fa6/lib/auto-updater.lua",
+			"lib/auto-updater.lua" => "raw.githubusercontent.com/hexarobi/stand-lua-constructor/a4a3dc7973b352b79dcf44e5056becc67a5af20a/lib/auto-updater.lua",
 			"lib/constructor/constants.lua" => "raw.githubusercontent.com/hexarobi/stand-lua-constructor/dc8c2e443c593c3029b17956ab17c453da554cad/lib/constructor/constants.lua",
 			"lib/constructor/constructor_lib.lua" => "raw.githubusercontent.com/hexarobi/stand-lua-constructor/dc8c2e443c593c3029b17956ab17c453da554cad/lib/constructor/constructor_lib.lua",
 			"lib/constructor/convertors.lua" => "raw.githubusercontent.com/hexarobi/stand-lua-constructor/dc8c2e443c593c3029b17956ab17c453da554cad/lib/constructor/convertors.lua",

--- a/data/packages.php
+++ b/data/packages.php
@@ -503,7 +503,7 @@ $packages = [
 		"priority" => 2,
 		"author" => "hexarobi",
 		"description" => "Load and edit custom map, vehicle and skin files in JSON, XML or INI format.",
-		"version" => "0.37.1r",
+		"version" => "0.37.2r",
 		"depends" => [
 			"lua/natives-1672190175",
 			"lua/iniparser",
@@ -512,7 +512,7 @@ $packages = [
 			"lua/quaternionLib",
 		],
 		"files" => [
-			"Constructor.lua" => "raw.githubusercontent.com/hexarobi/stand-lua-constructor/edf67b2210b45675dd18a0127177ef7ed2205fa6/Constructor.lua",
+			"Constructor.lua" => "raw.githubusercontent.com/hexarobi/stand-lua-constructor/58d3c90dbb0cd3cd36f8c93d55276d7e96dae828/Constructor.lua",
 			"lib/auto-updater.lua" => "raw.githubusercontent.com/hexarobi/stand-lua-constructor/edf67b2210b45675dd18a0127177ef7ed2205fa6/lib/auto-updater.lua",
 			"lib/constructor/constants.lua" => "raw.githubusercontent.com/hexarobi/stand-lua-constructor/dc8c2e443c593c3029b17956ab17c453da554cad/lib/constructor/constants.lua",
 			"lib/constructor/constructor_lib.lua" => "raw.githubusercontent.com/hexarobi/stand-lua-constructor/dc8c2e443c593c3029b17956ab17c453da554cad/lib/constructor/constructor_lib.lua",


### PR DESCRIPTION
- Fix bug with free edit mode
- Update updater to use async_http.have_access

If I am updating an existing package...

- [x] I have ensured that all modified files now have a different URL.
- [x] If resources were modified, I also made sure to bump the `resources_version`.
