### PR TITLE
update iniparser

### DIFF
--- a/data/packages.php
+++ b/data/packages.php
@@ -160,7 +160,7 @@ $packages = [
 		"author" => "well-in-that-case",
 		"version" => "0.2.10",
 		"files" => [
-			"lib/iniparser.lua" => "raw.githubusercontent.com/calamity-inc/iniparser/0.2.10/iniparser.lua",
+			"lib/iniparser.lua" => "raw.githubusercontent.com/calamity-inc/iniparser/7a84a2ae8559f850a80b6b23ff16e3e60770918c/iniparser.lua",
 		],
 	],
 	"lua/WiriScript" => [


### PR DESCRIPTION
The iniparser is labeled 0.2.10 but is missing the updates from the current main branch Constructor needs.
