### PR TITLE
 Bump Dolos to 3.0.0; fixed 404

### DIFF
--- a/data/packages.php
+++ b/data/packages.php
@@ -167,7 +167,7 @@ $packages = [
 		"depends" => [
 			"lua/natives-2944b",
 		],
-		"version" => "2.3.0",
+		"version" => "3.0.0",
 		"resources_version" => "2.3.0",
 		"files" => [
 			"Dolos.pluto" => "raw.githubusercontent.com/thebitwise/dolos/2.3.0/Dolos.pluto",

--- a/data/packages.php
+++ b/data/packages.php
@@ -170,7 +170,7 @@ $packages = [
 		"version" => "3.0.0",
 		"resources_version" => "2.3.0",
 		"files" => [
-			"Dolos.pluto" => "raw.githubusercontent.com/thebitwise/dolos/2.3.0/Dolos.pluto",
+			"Dolos.pluto" => "raw.githubusercontent.com/thebitwise/dolos/3.0.0/Dolos.pluto",
 		],
 		"resources" => [
 			"resources/dolos/attention.wav" => "raw.githubusercontent.com/thebitwise/dolos/2.3.0/resources/dolos/attention.wav",


### PR DESCRIPTION
If I am updating an existing package...

- [x] I have ensured that all modified files now have a different URL.
- [x] If resources were modified, I also made sure to bump the `resources_version`.
  
My release never got created, not sure how.