### PR TITLE
Bump Dolos to 4.0.0

### DIFF
--- a/data/packages.php
+++ b/data/packages.php
@@ -167,10 +167,10 @@ $packages = [
 		"depends" => [
 			"lua/natives-2944b",
 		],
-		"version" => "3.0.0",
+		"version" => "4.0.0",
 		"resources_version" => "2.3.0",
 		"files" => [
-			"Dolos.pluto" => "raw.githubusercontent.com/thebitwise/dolos/3.0.0/Dolos.pluto",
+			"Dolos.pluto" => "raw.githubusercontent.com/thebitwise/dolos/4.0.0/Dolos.pluto",
 		],
 		"resources" => [
 			"resources/dolos/attention.wav" => "raw.githubusercontent.com/thebitwise/dolos/2.3.0/resources/dolos/attention.wav",


### PR DESCRIPTION
If I am updating an existing package...

- [x] I have ensured that all modified files now have a different URL.
- [x] If resources were modified, I also made sure to bump the `resources_version`.
