### PR TITLE
Constructor 0.49.2r

### DIFF
--- a/data/packages.php
+++ b/data/packages.php
@@ -546,7 +546,7 @@ $packages = [
 		"priority" => PRIORITY_USEFUL_POPULAR,
 		"author" => "hexarobi",
 		"description" => "Load and edit custom map, vehicle and skin files in JSON, XML or INI format.",
-		"version" => "0.49.1r",
+		"version" => "0.49.2r",
 		"depends" => [
 			"lua/natives-3095a",
 			"lua/iniparser",
@@ -557,7 +557,7 @@ $packages = [
 			"lua/auto-updater",
 		],
 		"files" => [
-			"Constructor.lua" => "raw.githubusercontent.com/hexarobi/stand-lua-constructor/46fabb8ad63e0808ebd07f8d48f918ff0aa65b3a/Constructor.lua",
+			"Constructor.lua" => "raw.githubusercontent.com/hexarobi/stand-lua-constructor/57acf3f3ad2a44119b2cdf5559270f2aa19ccb89/Constructor.lua",
 			"lib/constructor/constants.lua" => "raw.githubusercontent.com/hexarobi/stand-lua-constructor/46fabb8ad63e0808ebd07f8d48f918ff0aa65b3a/lib/constructor/constants.lua",
 			"lib/constructor/constructor_lib.lua" => "raw.githubusercontent.com/hexarobi/stand-lua-constructor/46fabb8ad63e0808ebd07f8d48f918ff0aa65b3a/lib/constructor/constructor_lib.lua",
 			"lib/constructor/convertors.lua" => "raw.githubusercontent.com/hexarobi/stand-lua-constructor/46fabb8ad63e0808ebd07f8d48f918ff0aa65b3a/lib/constructor/convertors.lua",


### PR DESCRIPTION
-Bugfix for free edit mode

If I am updating an existing package...

- [x] I have ensured that all modified files now have a different URL.
- [x] If resources were modified, I also made sure to bump the `resources_version`.
